### PR TITLE
Major refactoring

### DIFF
--- a/breakwater-parser/benches/parsing.rs
+++ b/breakwater-parser/benches/parsing.rs
@@ -18,11 +18,13 @@ fn compare_implementations(c: &mut Criterion) {
         "benches/non-transparent.png",
         true,
         false,
+        false,
     );
     invoke_benchmark(
         c,
         "parse_draw_commands_ordered",
         "benches/non-transparent.png",
+        false,
         false,
         false,
     );
@@ -32,13 +34,15 @@ fn compare_implementations(c: &mut Criterion) {
         "benches/non-transparent.png",
         true,
         true,
+        false,
     );
     invoke_benchmark(
         c,
         "parse_mixed_draw_commands",
         "benches/mixed.png",
-        true,
         false,
+        false,
+        true,
     );
 }
 
@@ -48,6 +52,7 @@ fn invoke_benchmark(
     image: &str,
     shuffle: bool,
     use_offset: bool,
+    use_gray: bool,
 ) {
     let commands = image_handler::load(
         vec![image],
@@ -56,6 +61,7 @@ fn invoke_benchmark(
             .height(FRAMEBUFFER_HEIGHT as u32)
             .shuffle(shuffle)
             .offset_usage(use_offset)
+            .gray_usage(use_gray)
             .build(),
     )
     .pop()

--- a/breakwater-parser/benches/parsing.rs
+++ b/breakwater-parser/benches/parsing.rs
@@ -83,17 +83,17 @@ fn invoke_benchmark(
 }
 
 async fn invoke_simple_implementation(input: &[u8], fb: &Arc<FrameBuffer>) {
-    let mut parser = SimpleParser::default();
+    let mut parser = SimpleParser::new(fb.clone());
     parser
-        .parse(input, fb, DevNullTcpStream::default())
+        .parse(input, DevNullTcpStream::default())
         .await
         .expect("Failed to parse commands");
 }
 
-async fn _invoke_assembler_implementation(input: &[u8], fb: &Arc<FrameBuffer>) {
+async fn _invoke_assembler_implementation(input: &[u8], _fb: &Arc<FrameBuffer>) {
     let mut parser = AssemblerParser::default();
     parser
-        .parse(input, fb, DevNullTcpStream::default())
+        .parse(input, DevNullTcpStream::default())
         .await
         .expect("Failed to parse commands");
 }

--- a/breakwater-parser/src/implementations/assembler.rs
+++ b/breakwater-parser/src/implementations/assembler.rs
@@ -1,7 +1,6 @@
-use std::{arch::asm, sync::Arc};
+use std::arch::asm;
 
 use async_trait::async_trait;
-use breakwater_core::framebuffer::FrameBuffer;
 use tokio::io::AsyncWriteExt;
 
 use crate::{Parser, ParserError};
@@ -16,7 +15,6 @@ impl Parser for AssemblerParser {
     async fn parse(
         &mut self,
         buffer: &[u8],
-        _fb: &Arc<FrameBuffer>,
         _stream: impl AsyncWriteExt + Send + Unpin,
     ) -> Result<usize, ParserError> {
         let mut last_byte_parsed = 0;

--- a/breakwater-parser/src/implementations/simple.rs
+++ b/breakwater-parser/src/implementations/simple.rs
@@ -1,5 +1,5 @@
 use std::{
-    simd::{u32x8, Simd, SimdUint},
+    simd::{u32x8, Simd, num::SimdUint},
     sync::Arc,
 };
 

--- a/breakwater-parser/src/implementations/simple.rs
+++ b/breakwater-parser/src/implementations/simple.rs
@@ -184,6 +184,7 @@ impl Parser for SimpleParser {
     }
 }
 
+#[inline]
 const fn string_to_number(input: &[u8]) -> u64 {
     (input[7] as u64) << 56
         | (input[6] as u64) << 48

--- a/breakwater-parser/src/implementations/simple.rs
+++ b/breakwater-parser/src/implementations/simple.rs
@@ -141,7 +141,7 @@ impl Parser for SimpleParser {
                         continue;
                     }
                 }
-            } else if current_command & 0x0000_ffff_ffff_ffff == string_to_number(b"OFFSET \0\0") {
+            } else if current_command & 0x00ff_ffff_ffff_ffff == string_to_number(b"OFFSET \0\0") {
                 i += 7;
 
                 let (x, y, present) = parse_pixel_coordinates(buffer.as_ptr(), &mut i);

--- a/breakwater-parser/src/implementations/simple.rs
+++ b/breakwater-parser/src/implementations/simple.rs
@@ -12,10 +12,172 @@ use crate::{Parser, ParserError};
 
 const PARSER_LOOKAHEAD: usize = "PX 1234 1234 rrggbbaa\n".len(); // Longest possible command
 
-#[derive(Default)]
 pub struct SimpleParser {
     connection_x_offset: usize,
     connection_y_offset: usize,
+    fb: Arc<FrameBuffer>,
+}
+
+impl SimpleParser {
+    pub fn new(fb: Arc<FrameBuffer>) -> SimpleParser {
+        SimpleParser {
+            connection_x_offset: 0,
+            connection_y_offset: 0,
+            fb,
+        }
+    }
+
+    #[inline]
+    async fn handle_pixel(&self, buffer: &[u8], mut idx: usize, stream: &mut (impl AsyncWriteExt + Send + Unpin)) -> Result<usize, ParserError> {
+        let previous = idx;
+        idx += 3;
+
+        let (mut x, mut y, present) = parse_pixel_coordinates(buffer.as_ptr(), &mut idx);
+
+        if present {
+            x += self.connection_x_offset;
+            y += self.connection_y_offset;
+
+            // Separator between coordinates and color
+            if unsafe { *buffer.get_unchecked(idx) } == b' ' {
+                idx += 1;
+
+                // TODO: Determine what clients use more: RGB, RGBA or gg variant.
+                // If RGBA is used more often move the RGB code below the RGBA code
+
+                // Must be followed by 6 bytes RGB and newline or ...
+                if unsafe { *buffer.get_unchecked(idx + 6) } == b'\n' {
+                    idx += 7;
+                    self.handle_rgb(idx, buffer, x, y);
+                }
+
+                // ... or must be followed by 8 bytes RGBA and newline
+                else if unsafe { *buffer.get_unchecked(idx + 8) } == b'\n' {
+                    idx += 9;
+                    self.handle_rgba(idx, buffer, x, y);
+                }
+
+                // ... for the efficient/lazy clients
+                else if unsafe { *buffer.get_unchecked(idx + 2) } == b'\n' {
+                    idx += 3;
+                    self.handle_gray(idx, buffer, x, y);
+                } else {
+                    idx = previous
+                }
+            }
+
+            // End of command to read Pixel value
+            else if unsafe { *buffer.get_unchecked(idx) } == b'\n' {
+                idx += 1;
+                self.handle_get_pixel(stream, x, y).await?;
+            } else {
+                idx = previous
+            }
+        } else {
+            idx = previous
+        }
+        Ok(idx)
+    }
+
+    #[inline]
+    fn handle_offset(&mut self, idx: &mut usize, buffer: &[u8]) {
+        let (x, y, present) = parse_pixel_coordinates(buffer.as_ptr(), idx);
+
+        // End of command to set offset
+        if present && unsafe { *buffer.get_unchecked(*idx) } == b'\n' {
+            self.connection_x_offset = x;
+            self.connection_y_offset = y;
+        }
+    }
+
+    #[inline]
+    async fn handle_size(&self, stream: &mut (impl AsyncWriteExt + Send + Unpin)) -> Result<(), ParserError> {
+        stream
+            .write_all(format!("SIZE {} {}\n", self.fb.get_width(), self.fb.get_height()).as_bytes())
+            .await
+            .context(crate::WriteToTcpSocketSnafu)?;
+        Ok(())
+    }
+
+    #[inline]
+    async fn handle_help(&self, stream: &mut (impl AsyncWriteExt + Send + Unpin)) -> Result<(), ParserError> {
+        stream
+            .write_all(HELP_TEXT)
+            .await
+            .context(crate::WriteToTcpSocketSnafu)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn handle_rgb(&self, idx: usize, buffer: &[u8], x: usize, y: usize) {
+        let rgba: u32 = simd_unhex(unsafe { buffer.as_ptr().add(idx - 7) });
+
+        self.fb.set(x, y, rgba & 0x00ff_ffff);
+    }
+
+    #[cfg(not(feature = "alpha"))]
+    #[inline]
+    fn handle_rgba(&self, idx: usize, buffer: &[u8], x: usize, y: usize) {
+        let rgba: u32 = simd_unhex(unsafe { buffer.as_ptr().add(idx - 9) });
+
+        self.fb.set(x, y, rgba & 0x00ff_ffff);
+    }
+
+    #[cfg(feature = "alpha")]
+    #[inline]
+    fn handle_rgba(&self, idx: usize, buffer: &[u8], x: usize, y: usize) {
+        let rgba: u32 = simd_unhex(unsafe { buffer.as_ptr().add(idx - 9) });
+
+        let alpha = (rgba >> 24) & 0xff;
+
+        if alpha == 0 || x >= self.fb.get_width() || y >= self.fb.get_height() {
+            return
+        }
+
+        let alpha_comp = 0xff - alpha;
+        let current = self.fb.get_unchecked(x, y);
+        let r = (rgba >> 16) & 0xff;
+        let g = (rgba >> 8) & 0xff;
+        let b = rgba & 0xff;
+
+        let r: u32 = (((current >> 24) & 0xff) * alpha_comp + r * alpha) / 0xff;
+        let g: u32 = (((current >> 16) & 0xff) * alpha_comp + g * alpha) / 0xff;
+        let b: u32 = (((current >> 8) & 0xff) * alpha_comp + b * alpha) / 0xff;
+
+        self.fb.set(x, y, r << 16 | g << 8 | b);
+    }
+
+    #[inline]
+    fn handle_gray(&self, idx: usize, buffer: &[u8], x: usize, y: usize) {
+        // FIXME: Read that two bytes directly instead of going through the whole SIMD vector setup.
+        // Or - as an alternative - still do the SIMD part but only load two bytes.
+        let base: u32 =
+            simd_unhex(unsafe { buffer.as_ptr().add(idx - 3) }) & 0xff;
+
+        let rgba: u32 = base << 16 | base << 8 | base;
+
+        self.fb.set(x, y, rgba);
+    }
+
+    #[inline]
+    async fn handle_get_pixel(&self, stream: &mut(impl AsyncWriteExt + Send + Unpin), x: usize, y: usize) -> Result<(), ParserError> {
+        if let Some(rgb) = self.fb.get(x, y) {
+            stream
+                .write_all(
+                    format!(
+                        "PX {} {} {:06x}\n",
+                        // We don't want to return the actual (absolute) coordinates, the client should also get the result offseted
+                        x - self.connection_x_offset,
+                        y - self.connection_y_offset,
+                        rgb.to_be() >> 8
+                    )
+                        .as_bytes(),
+                )
+                .await
+                .context(crate::WriteToTcpSocketSnafu)?;
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -23,10 +185,8 @@ impl Parser for SimpleParser {
     async fn parse(
         &mut self,
         buffer: &[u8],
-        fb: &Arc<FrameBuffer>,
         mut stream: impl AsyncWriteExt + Send + Unpin,
     ) -> Result<usize, ParserError> {
-        let mut last_byte_parsed = 0;
         let mut i = 0; // We can't use a for loop here because Rust don't lets use skip characters by incrementing i
         let loop_end = buffer.len().saturating_sub(PARSER_LOOKAHEAD); // Let's extract the .len() call and the subtraction into it's own variable so we only compute it once
 
@@ -34,149 +194,22 @@ impl Parser for SimpleParser {
             let current_command =
                 unsafe { (buffer.as_ptr().add(i) as *const u64).read_unaligned() };
             if current_command & 0x00ff_ffff == string_to_number(b"PX \0\0\0\0\0") {
-                i += 3;
-
-                let (mut x, mut y, present) = parse_pixel_coordinates(buffer.as_ptr(), &mut i);
-
-                if present {
-                    x += self.connection_x_offset;
-                    y += self.connection_y_offset;
-
-                    // Separator between coordinates and color
-                    if unsafe { *buffer.get_unchecked(i) } == b' ' {
-                        i += 1;
-
-                        // TODO: Determine what clients use more: RGB, RGBA or gg variant.
-                        // If RGBA is used more often move the RGB code below the RGBA code
-
-                        // Must be followed by 6 bytes RGB and newline or ...
-                        if unsafe { *buffer.get_unchecked(i + 6) } == b'\n' {
-                            last_byte_parsed = i + 6;
-                            i += 7; // We can advance one byte more than normal as we use continue and therefore not get incremented at the end of the loop
-
-                            let rgba: u32 = simd_unhex(unsafe { buffer.as_ptr().add(i - 7) });
-
-                            fb.set(x, y, rgba & 0x00ff_ffff);
-                            continue;
-                        }
-
-                        // ... or must be followed by 8 bytes RGBA and newline
-                        #[cfg(not(feature = "alpha"))]
-                        if unsafe { *buffer.get_unchecked(i + 8) } == b'\n' {
-                            last_byte_parsed = i + 8;
-                            i += 9; // We can advance one byte more than normal as we use continue and therefore not get incremented at the end of the loop
-
-                            let rgba: u32 = simd_unhex(unsafe { buffer.as_ptr().add(i - 9) });
-
-                            fb.set(x, y, rgba & 0x00ff_ffff);
-                            continue;
-                        }
-                        #[cfg(feature = "alpha")]
-                        if unsafe { *buffer.get_unchecked(i + 8) } == b'\n' {
-                            last_byte_parsed = i + 8;
-                            i += 9; // We can advance one byte more than normal as we use continue and therefore not get incremented at the end of the loop
-
-                            let rgba: u32 = simd_unhex(unsafe { buffer.as_ptr().add(i - 9) });
-
-                            let alpha = (rgba >> 24) & 0xff;
-
-                            if alpha == 0 || x >= fb.get_width() || y >= fb.get_height() {
-                                continue;
-                            }
-
-                            let alpha_comp = 0xff - alpha;
-                            let current = fb.get_unchecked(x, y);
-                            let r = (rgba >> 16) & 0xff;
-                            let g = (rgba >> 8) & 0xff;
-                            let b = rgba & 0xff;
-
-                            let r: u32 = (((current >> 24) & 0xff) * alpha_comp + r * alpha) / 0xff;
-                            let g: u32 = (((current >> 16) & 0xff) * alpha_comp + g * alpha) / 0xff;
-                            let b: u32 = (((current >> 8) & 0xff) * alpha_comp + b * alpha) / 0xff;
-
-                            fb.set(x, y, r << 16 | g << 8 | b);
-                            continue;
-                        }
-
-                        // ... for the efficient/lazy clients
-                        if unsafe { *buffer.get_unchecked(i + 2) } == b'\n' {
-                            last_byte_parsed = i + 2;
-                            i += 3; // We can advance one byte more than normal as we use continue and therefore not get incremented at the end of the loop
-
-                            // FIXME: Read that two bytes directly instead of going through the whole SIMD vector setup.
-                            // Or - as an alternative - still do the SIMD part but only load two bytes.
-                            let base: u32 =
-                                simd_unhex(unsafe { buffer.as_ptr().add(i - 3) }) & 0xff;
-
-                            let rgba: u32 = base << 16 | base << 8 | base;
-
-                            fb.set(x, y, rgba);
-
-                            continue;
-                        }
-                    }
-
-                    // End of command to read Pixel value
-                    if unsafe { *buffer.get_unchecked(i) } == b'\n' {
-                        last_byte_parsed = i;
-                        i += 1;
-                        if let Some(rgb) = fb.get(x, y) {
-                            match stream
-                                .write_all(
-                                    format!(
-                                        "PX {} {} {:06x}\n",
-                                        // We don't want to return the actual (absolute) coordinates, the client should also get the result offseted
-                                        x - self.connection_x_offset,
-                                        y - self.connection_y_offset,
-                                        rgb.to_be() >> 8
-                                    )
-                                    .as_bytes(),
-                                )
-                                .await
-                            {
-                                Ok(_) => (),
-                                Err(_) => continue,
-                            }
-                        }
-                        continue;
-                    }
-                }
+                i = self.handle_pixel(buffer, i, &mut stream).await?;
             } else if current_command & 0x00ff_ffff_ffff_ffff == string_to_number(b"OFFSET \0\0") {
                 i += 7;
-
-                let (x, y, present) = parse_pixel_coordinates(buffer.as_ptr(), &mut i);
-
-                // End of command to set offset
-                if present && unsafe { *buffer.get_unchecked(i) } == b'\n' {
-                    last_byte_parsed = i;
-                    self.connection_x_offset = x;
-                    self.connection_y_offset = y;
-                    continue;
-                }
+                self.handle_offset(&mut i, buffer);
             } else if current_command & 0xffff_ffff == string_to_number(b"SIZE\0\0\0\0") {
                 i += 4;
-                last_byte_parsed = i - 1;
-
-                stream
-                    .write_all(format!("SIZE {} {}\n", fb.get_width(), fb.get_height()).as_bytes())
-                    .await
-                    .context(crate::WriteToTcpSocketSnafu)?;
-                continue;
+                self.handle_size(&mut stream).await?;
             } else if current_command & 0xffff_ffff == string_to_number(b"HELP\0\0\0\0") {
                 i += 4;
-                last_byte_parsed = i - 1;
-
-                stream
-                    .write_all(HELP_TEXT)
-                    .await
-                    .context(crate::WriteToTcpSocketSnafu)?;
-                continue;
+                self.handle_help(&mut stream).await?;
+            } else {
+                i += 1;
             }
-
-            i += 1;
         }
 
-        Ok(last_byte_parsed)
+        Ok(i - 1)
     }
 
     fn parser_lookahead() -> usize {

--- a/breakwater-parser/src/lib.rs
+++ b/breakwater-parser/src/lib.rs
@@ -1,10 +1,7 @@
 // Needed for simple implementation
 #![feature(portable_simd)]
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
-use breakwater_core::framebuffer::FrameBuffer;
 use snafu::Snafu;
 use tokio::io::AsyncWriteExt;
 
@@ -21,7 +18,6 @@ pub trait Parser {
     async fn parse(
         &mut self,
         buffer: &[u8],
-        fb: &Arc<FrameBuffer>,
         stream: impl AsyncWriteExt + Send + Unpin,
     ) -> Result<usize, ParserError>;
 

--- a/breakwater/src/server.rs
+++ b/breakwater/src/server.rs
@@ -115,7 +115,7 @@ pub async fn handle_connection(
     // Number bytes left over **on the first bytes of the buffer** from the previous loop iteration
     let mut leftover_bytes_in_buffer = 0;
 
-    let mut parser: SimpleParser = SimpleParser::default();
+    let mut parser: SimpleParser = SimpleParser::new(fb);
     // let mut parser: AssemblerParser = AssemblerParser::default();
     let parser_lookahead = SimpleParser::parser_lookahead();
 
@@ -172,7 +172,7 @@ pub async fn handle_connection(
             }
 
             let last_byte_parsed = parser
-                .parse(&buffer[..data_end + parser_lookahead], &fb, &mut stream)
+                .parse(&buffer[..data_end + parser_lookahead], &mut stream)
                 .await
                 .context(ParsePixelflutCommandsSnafu)?;
 


### PR DESCRIPTION
While the first set of commits focuses on fixing bugs that have already been fixed in breakwater (and adjusting the benchmarks to be functionally equivalent across `breakwater` and `breakwater-rewrite-2`), the last commit is a radical restructuring of the parser aimed towards better readability.

Tests are stuck in an infinite loop as of now.

The difference between `breakwater-rewrite-2` and `breakwater` is within margin of error without the major restructuring.